### PR TITLE
Fix offset for extendedGateway parsing when IPv6

### DIFF
--- a/lib/packet.js
+++ b/lib/packet.js
@@ -63,7 +63,7 @@ internal.defaultFlowRecords = function (flow, buf) {
             b = buf.slice(8);
             flow.ipVersion = b.readUInt32BE(0);
             flow.ipNextHop = flow.ipVersion==2?ipv6decode(b.slice(4)):ipv4decode(b.slice(4));
-            b = b.slice(flow.ipVersion*16-8);
+            b = b.slice(flow.ipVersion==2?20:8);
             flow.routerAs = b.readUInt32BE(0);
             flow.srcAs = b.readUInt32BE(4);
             flow.srcPeerAs = b.readUInt32BE(8);


### PR DESCRIPTION
If IPv4 we need to move forward 8 bytes, which works with the existing code (1*16-8 = 8)
If IPv6 we need to move forward 20 bytes, but existing code has us move 2*16-8=24 bytes. At best this results in a corrupted record, at worst it crashes a few lines later due to trying to read past buffer length.
